### PR TITLE
Migrate dbt-date to GoDataDriven

### DIFF
--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,6 +1,6 @@
 packages:
-- package: dbt-labs/dbt_utils
-  version: 1.0.0
-- package: calogica/dbt_date
-  version: 0.7.2
-sha1_hash: cbc2e0bc40cab400d43245bcfa8ce04f099c1610
+  - package: dbt-labs/dbt_utils
+    version: 1.0.0
+  - package: godatadriven/dbt_date
+    version: 0.7.2
+sha1_hash: 8f4e55aace46536ae062945950e28b7b41747cb0

--- a/packages.yml
+++ b/packages.yml
@@ -1,6 +1,6 @@
 packages:
   - package: dbt-labs/dbt_utils
     version: 1.0.0
-  - package: calogica/dbt_date
+  - package: godatadriven/dbt_date
     version: [">=0.7.0", "<0.8.0"]
     # <see https://github.com/calogica/dbt-date/releases/latest> for the latest version tag


### PR DESCRIPTION
Calogica's [dbt-date](https://github.com/calogica/dbt-date) package is no longer supported. Instead, GoDataDriven's [dbt-date](https://github.com/metaplane/dbt-date) package is now featured on the [dbt Package Hub](https://hub.getdbt.com/godatadriven/dbt_date/latest/). This PR migrates the dependency in this repo.