### PR TITLE
Pin GitHub Actions to specific SHAs (2 actions in 1 files)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ jobs:
   dbt-build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # actions/checkout@v3
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # actions/setup-python@v4
         with:
           python-version: "3.10"
           cache: 'pip'


### PR DESCRIPTION
## 📌 Pin GitHub Actions to Specific SHAs

This PR updates GitHub Actions references from tags/branches to specific commit SHAs for improved security and reproducibility.

### 📊 Summary
- **Files changed**: 1
- **Actions pinned**: 2

### 📝 Changes by file

#### `.github/workflows/ci.yml`

- 📌 `actions/checkout@v3` → `actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # actions/checkout@v3`
- 📌 `actions/setup-python@v4` → `actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c  # actions/setup-python@v4`

